### PR TITLE
DTSPO-588 - Enable flux admin applications

### DIFF
--- a/k8s/environments/prod/cluster-00-overlay/.flux.yaml
+++ b/k8s/environments/prod/cluster-00-overlay/.flux.yaml
@@ -1,0 +1,4 @@
+version: 1
+commandUpdated:
+  generators:
+    - command: kustomize build --load_restrictor none .

--- a/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+# - ../../../release/admin/kube-slack
+# - ../../../release/admin/traefik
+# - ../../../release/admin/kured
+- ../../../release/admin/keyvault-flexvol
+- ../../../release/admin/secrets-csi-driver
+- ../../../namespaces/azure-devops
+- ../../../namespaces/admin/aad-pod-identity
+- ../../../namespaces/kube-system/aad-pod-identity
+# - ../../../release/admin/env-injector
+# - ../../../release/kube-system/nodelocaldns
+
+patchesStrategicMerge:
+
+#kube-slack patch
+# - ../../../release/admin/kube-slack/patches/prod/cluster-00/kube-slack.yaml
+
+#traefik patch
+# - ../../../release/admin/traefik/patches/prod/cluster-00/traefik.yaml
+
+#kured patch
+# - ../../../release/admin/kured/patches/prod/cluster-00/kured.yaml
+
+#azure-devops-agent patch
+- ../../../namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml
+
+# env-injector
+# - ../../../release/admin/env-injector/patches/prod/cluster-00/env-injector.yaml

--- a/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
@@ -4,7 +4,6 @@ bases:
 # - ../../../release/admin/kube-slack
 # - ../../../release/admin/traefik
 # - ../../../release/admin/kured
-- ../../../release/admin/keyvault-flexvol
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/azure-devops
 - ../../../namespaces/admin/aad-pod-identity

--- a/k8s/environments/prod/cluster-01-overlay/.flux.yaml
+++ b/k8s/environments/prod/cluster-01-overlay/.flux.yaml
@@ -1,0 +1,4 @@
+version: 1
+commandUpdated:
+  generators:
+    - command: kustomize build --load_restrictor none .

--- a/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+# - ../../../release/admin/kube-slack
+# - ../../../release/admin/traefik
+# - ../../../release/admin/kured
+- ../../../release/admin/keyvault-flexvol
+- ../../../release/admin/secrets-csi-driver
+- ../../../namespaces/azure-devops
+- ../../../namespaces/admin/aad-pod-identity
+- ../../../namespaces/kube-system/aad-pod-identity
+# - ../../../release/admin/env-injector
+# - ../../../release/kube-system/nodelocaldns
+
+patchesStrategicMerge:
+
+#kube-slack patch
+# - ../../../release/admin/kube-slack/patches/prod/cluster-01/kube-slack.yaml
+
+#traefik patch
+# - ../../../release/admin/traefik/patches/prod/cluster-01/traefik.yaml
+
+#kured patch
+# - ../../../release/admin/kured/patches/prod/cluster-01/kured.yaml
+
+#azure-devops-agent patch
+- ../../../namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml
+
+# env-injector
+# - ../../../release/admin/env-injector/patches/prod/cluster-00/env-injector.yaml

--- a/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
@@ -4,7 +4,6 @@ bases:
 # - ../../../release/admin/kube-slack
 # - ../../../release/admin/traefik
 # - ../../../release/admin/kured
-- ../../../release/admin/keyvault-flexvol
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/azure-devops
 - ../../../namespaces/admin/aad-pod-identity

--- a/k8s/namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml
+++ b/k8s/namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: azure-devops-agent
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.chart-image: glob:v*
+spec:
+  releaseName: azure-devops-agent
+  values:
+    aadIdentity:
+      resourceId: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-prod-mi
+      clientId: 7af92e77-4559-4a31-852e-0432884c3886
+    azureDevOps:
+      pool: hmcts-ss-prod
+    keyVaults:
+    - name: dtssharedservicesprodkv
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      secrets:
+      - azure-devops-agent-token    

--- a/k8s/namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-01/azure-devops-agent.yaml
+++ b/k8s/namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-01/azure-devops-agent.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: azure-devops-agent
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.chart-image: glob:v*
+spec:
+  releaseName: azure-devops-agent
+  values:
+    aadIdentity:
+      resourceId: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-prod-mi
+      clientId: 7af92e77-4559-4a31-852e-0432884c3886
+    azureDevOps:
+      pool: hmcts-ss-prod
+    keyVaults:
+    - name: dtssharedservicesprodkv
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      secrets:
+      - azure-devops-agent-token    

--- a/k8s/stg/releases/mi/mi-data-extractor.yaml
+++ b/k8s/stg/releases/mi/mi-data-extractor.yaml
@@ -18,7 +18,7 @@ spec:
     ref: master
   values:
     job:
-      image: ssprivatestg.azurecr.io/data-extractor-job:stg-9872fa3
+      image: ssprivatestg.azurecr.io/data-extractor-job:stg-f86aea9
       suspend: false
       kind: CronJob
       schedule: '0 0 * * *'
@@ -30,7 +30,7 @@ spec:
         ETL_MSICLIENTID: e7251f8f-268e-4d5f-98d1-8eb777ef71c3
         APPINSIGHTS_INSTRUMENTATIONKEY: "482eb1b8-a656-41e6-b2e8-8351d7986b2c"
       smoketests:
-        image: ssprivatestg.azurecr.io/data-extractor-job:stg-9872fa3
+        image: ssprivatestg.azurecr.io/data-extractor-job:stg-f86aea9
         enabled: true
       testsConfig:
         environment:

--- a/k8s/stg/releases/video-hearings/vh-video-api.yaml
+++ b/k8s/stg/releases/video-hearings/vh-video-api.yaml
@@ -14,7 +14,7 @@ spec:
     path: k8s/charts/video-hearings
     ref: master
   values:
-    image: sspublicstg.azurecr.io/vh-video-api:master-87b3eba0162033c357c58cc064afa7f18d4d3fa0
+    image: sspublicstg.azurecr.io/vh-video-api:master-94d5bab4a54128319a6bf0c631357522d9538329
     pullPolicy: Always
     replicaCount: 0
     service:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-588


### Change description ###
Update to create flux folder structure in prod to deploy admin components and azure devops agent.

Note: Kube-slack, Kured and traefik manifests are currently disabled and to be enable later as required once the base components are in place and tested.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
