### PR TITLE
Add namespace so that kubectl apply -f works

### DIFF
--- a/k8s/namespaces/admin/aad-pod-identity/mic-exception.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/mic-exception.yaml
@@ -2,6 +2,7 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
   name: mic-exception
+  namespace: admin
 spec:
   podLabels:
     app: mic

--- a/k8s/namespaces/kube-system/aad-pod-identity/mic-exception.yaml
+++ b/k8s/namespaces/kube-system/aad-pod-identity/mic-exception.yaml
@@ -2,6 +2,7 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
   name: aks-addon-exception
+  namespace: kube-system
 spec:
   podLabels:
     kubernetes.azure.com/managedby: aks


### PR DESCRIPTION
Hitting an issue where the exception can't be applied in the same apply
as the CRD, so just applying the exception separately after, don't think
I really need kustomize for this
