### PR TITLE
DTSPO 588 - enable kured and traefik

### DIFF
--- a/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-00-overlay/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
-# - ../../../release/admin/traefik
-# - ../../../release/admin/kured
+- ../../../release/admin/traefik
+- ../../../release/admin/kured
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/azure-devops
 - ../../../namespaces/admin/aad-pod-identity
@@ -17,10 +17,10 @@ patchesStrategicMerge:
 # - ../../../release/admin/kube-slack/patches/prod/cluster-00/kube-slack.yaml
 
 #traefik patch
-# - ../../../release/admin/traefik/patches/prod/cluster-00/traefik.yaml
+- ../../../release/admin/traefik/patches/prod/cluster-00/traefik.yaml
 
 #kured patch
-# - ../../../release/admin/kured/patches/prod/cluster-00/kured.yaml
+- ../../../release/admin/kured/patches/prod/cluster-00/kured.yaml
 
 #azure-devops-agent patch
 - ../../../namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml

--- a/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
-# - ../../../release/admin/traefik
-# - ../../../release/admin/kured
+- ../../../release/admin/traefik
+- ../../../release/admin/kured
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/azure-devops
 - ../../../namespaces/admin/aad-pod-identity
@@ -17,10 +17,10 @@ patchesStrategicMerge:
 # - ../../../release/admin/kube-slack/patches/prod/cluster-01/kube-slack.yaml
 
 #traefik patch
-# - ../../../release/admin/traefik/patches/prod/cluster-01/traefik.yaml
+- ../../../release/admin/traefik/patches/prod/cluster-01/traefik.yaml
 
 #kured patch
-# - ../../../release/admin/kured/patches/prod/cluster-01/kured.yaml
+- ../../../release/admin/kured/patches/prod/cluster-01/kured.yaml
 
 #azure-devops-agent patch
 - ../../../namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-00/azure-devops-agent.yaml

--- a/k8s/environments/prod/common/secrets/kured-values.yaml
+++ b/k8s/environments/prod/common/secrets/kured-values.yaml
@@ -1,0 +1,23 @@
+apiVersion: ENC[AES256_GCM,data:33Q=,iv:euF/6YyXNQPiCdPt1RYvMaAMJFZbmkiixuYrVMO3sUo=,tag:Y44ZYKOrLYt4uCrZJCIF3Q==,type:str]
+data:
+    values.yaml: ENC[AES256_GCM,data:TAGUj6c8cBjDmktESIYFdIp/bxWgBOsuxGuotZPuZSOp6bRsPv/IqyCmht3fEI3yEY4NDRxw9zBgPnnZTIdmqa/zC4CAptsoZ8ze0HC7EwjOBvYJnYcHWpcyLyZt9xdxBFz4kjigjg9lLiQk7HIWYEvCwqEbxVFbaX/fgyrfk6318bO42IkZKP2V764=,iv:9oA5mwzLQ6xyNLHe806wPRuJpOzvEgt42LPt3l1CnOo=,tag:Km1zteIM3aPX1vnFYywtiw==,type:str]
+kind: ENC[AES256_GCM,data:2qOql7CV,iv:tyyYNo2OV1oRDcjx5aDfKXjHzWRqN6BxLlWy3HONpwU=,tag:DQ+eeVtXMZFCNsAuNj1w9g==,type:str]
+metadata:
+    creationTimestamp: null
+    name: ENC[AES256_GCM,data:W3bb2O9IRuIv8+Ge,iv:qqJZ7Cz/GmS36cctcs9rc81zgnpTeicGBmliZkLLCM8=,tag:japh2BZeKD3IMlubTsBZoQ==,type:str]
+    namespace: ENC[AES256_GCM,data:9fhTlg8=,iv:7776qwZXWpt/u8Uq1Das+v0m5ng+eWvnfbJ3+noIo+8=,tag:yPh7nloL8Q6GU2MLkaH2Zg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv:
+    -   vault_url: https://dtssharedservicesprodkv.vault.azure.net
+        name: sops-key
+        version: 883d8b431ad345d09b2697c3aaae2a0c
+        created_at: '2021-01-15T10:45:07Z'
+        enc: uGHS6peK6irS-amLSsxUaGXlPZIdXHbDEAMeUY6SBs0stjmiy68WmOWeEtDWKC-5xCHHYAdZfdge2W0u1pjsrF9gK9d2OWQw0pBMdebBGqQhRK5h9_15L5cs3kzENu1pjkI991YhWT7vpwel6JAAwQELDeepp3naG4ZLppdrT6j7ofv_IGGUZujso8-1o3zHelgGRSv_Z3hA3oj6yPdjf3elo-Q04zL5wMokCb92ek7a417-zyNMinOww9bNX-Ewt-LwZ5EMg8neEhiJA6C3oZFCA2UEFIrbZEk-nFBrAq25jACKn2Up23dgQMScWaGzA4L8sGOXIhurf3vaxUKkmg
+    hc_vault: []
+    lastmodified: '2021-01-15T10:45:08Z'
+    mac: ENC[AES256_GCM,data:3gOrL8Vi4/2oU6tp2yTrqgqec5EwezcdmS05JwW/WXNctI9KrPLTR9l5oWUTeopzRTmpgZywridTd9Zbs1I4NUtvh6wylzN6q1zy4jaZFcmzLU1hA5rCoiUZkv9ysMWhrSpM3xciI0zSQtFzNv6UBZh0TPcHXxenhL1bxPA99J8=,iv:0VlLAuisnVkNpoO1h84VahGBpfbuRSh8GQEXmoPEmwU=,tag:GB7xbamIMuESQanMXZEmUQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/k8s/release/admin/kured/patches/prod/cluster-00/kured.yaml
+++ b/k8s/release/admin/kured/patches/prod/cluster-00/kured.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: kured
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      slack-username: prod-00-aks
+      slack-channel: aks-monitor-ss

--- a/k8s/release/admin/kured/patches/prod/cluster-01/kured.yaml
+++ b/k8s/release/admin/kured/patches/prod/cluster-01/kured.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: kured
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      slack-username: prod-01-aks
+      slack-channel: aks-monitor-ss

--- a/k8s/release/admin/traefik/patches/prod/cluster-00/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/prod/cluster-00/traefik.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: admin
+spec:
+  values:
+    loadBalancerIP: 10.144.15.250
+    dashboard:
+      domain: traefik-ss-00.prod.platform.hmcts.net
+    accessLogs:
+      enabled: true
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 2
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"
+

--- a/k8s/release/admin/traefik/patches/prod/cluster-00/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/prod/cluster-00/traefik.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     loadBalancerIP: 10.144.15.250
     dashboard:
-      domain: traefik-ss-00.prod.platform.hmcts.net
+      domain: traefik-ss-00.platform.hmcts.net
     accessLogs:
       enabled: true
     autoscaling:
@@ -29,4 +29,3 @@ spec:
       podAnnotations:
         prometheus.io/port: "9100"
         prometheus.io/scrape: "true"
-

--- a/k8s/release/admin/traefik/patches/prod/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/prod/cluster-01/traefik.yaml
@@ -1,0 +1,31 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: admin
+spec:
+  values:
+    loadBalancerIP: 10.144.31.250
+    dashboard:
+      domain: traefik-ss-01.prod.platform.hmcts.net
+    accessLogs:
+      enabled: true
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 2
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"

--- a/k8s/release/admin/traefik/patches/prod/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/prod/cluster-01/traefik.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     loadBalancerIP: 10.144.31.250
     dashboard:
-      domain: traefik-ss-01.prod.platform.hmcts.net
+      domain: traefik-ss-01.platform.hmcts.net
     accessLogs:
       enabled: true
     autoscaling:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-588


### Change description ###
Update to enable Kured and Traefik on new shared service prod cluster
Leaving kube-slack disabled as I understand no longer in use

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
