### PR TITLE
Add Historical Notify Ingestion Job for MI Prod

### DIFF
--- a/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
+++ b/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
@@ -41,7 +41,7 @@ spec:
         DATA_SOURCE_EIGHTBYEIGHT: false
         DATA_SOURCE_PAYMENT: false
         DATA_SOURCE_HISTORICAL_NOTIFY: true
-        HISTORICAL_NOTIFY_CONTAINER: notify
+        HISTORICAL_NOTIFY_CONTAINER: historical-notify
       smoketests:
         image: ssprivateprod.azurecr.io/mi-integration-service:prod-0c90d42
         enabled: true

--- a/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
+++ b/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: mi-integration-service-historical-notify
+  namespace: mi
+  annotations:
+    flux.weave.works/automated: "true"
+    repository.fluxcd.io/job: job.image
+    filter.fluxcd.io/job: glob:prod-*
+    repository.fluxcd.io/smoke: job.smoketests.image
+    filter.fluxcd.io/smoke: glob:prod-*
+spec:
+  releaseName: mi-integration-service-historical-notify
+  chart:
+    git: git@github.com:hmcts/shared-services-flux
+    path: k8s/release/mi/mi-integration-service
+    ref: master
+  values:
+    job:
+      image: ssprivateprod.azurecr.io/mi-integration-service:prod-0c90d42
+      suspend: false
+      kind: Job
+      activeDeadlineSeconds: 82800 #23 hours
+      labels:
+        app.kubernetes.io/instance: mi-integration-service-historical-notify-job
+        app.kubernetes.io/name: mi-integration-service-historical-notify-job
+      keyVaults:
+        "mi-vault":
+          excludeEnvironmentSuffix: false
+          resourceGroup: mi-{{ .Values.global.environment }}-rg
+          secrets:
+          - appinsights-instrumentationkey
+          - mi-historical-storage-connection-string
+      environment:
+        MI_CLIENT_ID: ee31a18f-45e9-41db-881d-5976695188fb
+        APPINSIGHTS_INSTRUMENTATIONKEY: "8bfa6e68-ae68-442c-a237-83cde3b092f3"
+        DATA_SOURCE_CCD: false
+        DATA_SOURCE_NOTIFY: false
+        DATA_SOURCE_EIGHTBYEIGHT: false
+        DATA_SOURCE_PAYMENT: false
+        DATA_SOURCE_HISTORICAL_NOTIFY: true
+        HISTORICAL_NOTIFY_CONTAINER: notify
+      smoketests:
+        image: ssprivateprod.azurecr.io/mi-integration-service:prod-0c90d42
+        enabled: true
+      testsConfig:
+        keyVaults:
+          "mi-vault":
+            excludeEnvironmentSuffix: false
+            resourceGroup: mi-{{ .Values.global.environment }}-rg
+            secrets:
+            - appinsights-instrumentationkey
+            - mi-historical-storage-connection-string
+        environment:
+          MI_CLIENT_ID: ee31a18f-45e9-41db-881d-5976695188fb
+          APPINSIGHTS_INSTRUMENTATIONKEY: "8bfa6e68-ae68-442c-a237-83cde3b092f3"
+          DATA_SOURCE_CCD: false
+          DATA_SOURCE_NOTIFY: false
+          DATA_SOURCE_EIGHTBYEIGHT: false
+          DATA_SOURCE_PAYMENT: false
+          DATA_SOURCE_HISTORICAL_NOTIFY: true
+    global:
+      subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: "prod"

--- a/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
+++ b/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
@@ -19,8 +19,8 @@ spec:
   values:
     job:
       image: ssprivateprod.azurecr.io/mi-integration-service:prod-0c90d42
-      suspend: false
-      kind: Job
+      suspend: true
+      kind: CronJob
       activeDeadlineSeconds: 82800 #23 hours
       labels:
         app.kubernetes.io/instance: mi-integration-service-historical-notify-job

--- a/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
+++ b/k8s/environments/prod/cluster-00/mi/mi-integration-service-historical-notify.yaml
@@ -21,6 +21,7 @@ spec:
       image: ssprivateprod.azurecr.io/mi-integration-service:prod-0c90d42
       suspend: true
       kind: CronJob
+      schedule: '15 1 * * *'
       activeDeadlineSeconds: 82800 #23 hours
       labels:
         app.kubernetes.io/instance: mi-integration-service-historical-notify-job


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RMI-1044

### Change description ###

Adds a one time job to ingest all historical notify data from a specified storage account (stored in key vault)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
