### PR TITLE
Reduce default buffer size of mi staging service

### DIFF
--- a/k8s/environments/prod/cluster-00/mi/mi-staging-service.yaml
+++ b/k8s/environments/prod/cluster-00/mi/mi-staging-service.yaml
@@ -29,6 +29,7 @@ spec:
       environment:
         APPINSIGHTS_INSTRUMENTATIONKEY: "8bfa6e68-ae68-442c-a237-83cde3b092f3"
         MI_CLIENT_ID: ce15efbc-13a8-40ee-8812-334a7d041910
+        MAXLINESBUFFER: 500
       smoketests:
         image: ssprivateprod.azurecr.io/mi-staging-service:prod-d2ac116
         enabled: true


### PR DESCRIPTION
### Change description ###

Failing on some blobs due to Out of Memory issue. This is happening on a String join which is combining a List of 3000 objects into a String. This change reduces the maximum number of objects the list can contain to 500.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
