### PR TITLE
Removed duplicate namespace from kustomized env

### DIFF
--- a/k8s/environments/dev/common/mi/mi.yaml
+++ b/k8s/environments/dev/common/mi/mi.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mi

--- a/k8s/environments/test/common/mi/mi.yaml
+++ b/k8s/environments/test/common/mi/mi.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mi


### PR DESCRIPTION
Envs supporting kustomize for the specified namespace can derive its namespace details from the k8s/namespaces directory instead.