### PR TITLE
Fixed wrong resourceGroup for vaults and bumped chart versions

### DIFF
--- a/k8s/release/mi/common/job/Chart.yaml
+++ b/k8s/release/mi/common/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for HMCTS Kubernetes Job / CronJob
 name: job
-version: 0.6.1
+version: 0.6.2
 keywords:
   - Job
   - CronJob

--- a/k8s/release/mi/common/job/templates/secretprovider.yaml
+++ b/k8s/release/mi/common/job/templates/secretprovider.yaml
@@ -19,7 +19,7 @@ spec:
           objectType: secret
           objectVersion: ""
     {{- end }}
-    resourceGroup: {{ $val.resourceGroup }}
+    resourceGroup: {{ tpl $val.resourceGroup $ }}
     subscriptionId: {{ $globals.subscriptionId }}
     tenantId: {{ $globals.tenantId }} 
     {{- end }}

--- a/k8s/release/mi/mi-data-extractor-job/Chart.yaml
+++ b/k8s/release/mi/mi-data-extractor-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-data-extractor-job
 home: https://github.com/hmcts/data-extractor
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 type: application
 description: MI data extractor
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.1
+    version: ~0.6.2
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-extraction-service/Chart.yaml
+++ b/k8s/release/mi/mi-extraction-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-extraction-service
 home: https://github.com/hmcts/mi-extraction-service
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 type: application
 description: MI extraction service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.1
+    version: ~0.6.2
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-house-keeping-service/Chart.yaml
+++ b/k8s/release/mi/mi-house-keeping-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-house-keeping-service
 home: https://github.com/hmcts/mi-house-keeping-service
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 type: application
 description: MI House Keeping Service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.1
+    version: ~0.6.2
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-integration-service/Chart.yaml
+++ b/k8s/release/mi/mi-integration-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-integration-service
 home: https://github.com/hmcts/mi-integration-service
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 type: application
 description: MI integration service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.1
+    version: ~0.6.2
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-staging-service/Chart.yaml
+++ b/k8s/release/mi/mi-staging-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-staging-service
 home: https://github.com/hmcts/mi-staging-service
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 type: application
 description: MI staging service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.1
+    version: ~0.6.2
     repository: 'file://../common/job'


### PR DESCRIPTION
Helm doesn't interpolate values in the values.yaml by default.
This updates the mi-job chart to template the variable before using it in the context.