### PR TITLE
Update identity used by mi-sftp and simplified mi-job chart secret provider naming

### DIFF
--- a/k8s/namespaces/mi/mi-sftp-server/mi-sftp-server.yaml
+++ b/k8s/namespaces/mi/mi-sftp-server/mi-sftp-server.yaml
@@ -11,12 +11,12 @@ spec:
   selector:
     matchLabels:
       app: mi-sftp-server
-      aadpodidbinding: mi-data-extractor-job
+      aadpodidbinding: mi-extraction-service
   template:
     metadata:
       labels:
         app: mi-sftp-server
-        aadpodidbinding: mi-data-extractor-job
+        aadpodidbinding: mi-extraction-service
     spec:
       initContainers:
         - name: install

--- a/k8s/release/mi/common/job/Chart.yaml
+++ b/k8s/release/mi/common/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for HMCTS Kubernetes Job / CronJob
 name: job
-version: 0.6.2
+version: 0.6.3
 keywords:
   - Job
   - CronJob

--- a/k8s/release/mi/common/job/templates/_helpers.tpl
+++ b/k8s/release/mi/common/job/templates/_helpers.tpl
@@ -99,7 +99,7 @@ volumes:
       driver: secrets-store.csi.k8s.io
       readOnly: true
       volumeAttributes:
-        secretProviderClass: "{{ $releaseName }}-vault-{{ $globals.environment }}-secret-provider"
+        secretProviderClass: "{{ $releaseName }}-vault-secret-provider"
   {{- end }}
 {{- end }}
 securityContext:

--- a/k8s/release/mi/common/job/templates/_jobspec.tpl
+++ b/k8s/release/mi/common/job/templates/_jobspec.tpl
@@ -31,7 +31,7 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "{{ $releaseName }}-vault-{{ $globals.environment }}-secret-provider"
+              secretProviderClass: "{{ $releaseName }}-vault-secret-provider"
         {{- end }}
       {{- end }}
       securityContext:

--- a/k8s/release/mi/common/job/templates/secretprovider.yaml
+++ b/k8s/release/mi/common/job/templates/secretprovider.yaml
@@ -4,7 +4,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
-  name: "{{ include "hmcts.releaseName" . }}-vault-{{ $globals.environment }}-secret-provider"
+  name: "{{ include "hmcts.releaseName" . }}-vault-secret-provider"
 spec:
   provider: azure
   parameters:

--- a/k8s/release/mi/mi-data-extractor-job/Chart.yaml
+++ b/k8s/release/mi/mi-data-extractor-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-data-extractor-job
 home: https://github.com/hmcts/data-extractor
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.0.0"
 type: application
 description: MI data extractor
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.2
+    version: ~0.6.3
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-extraction-service/Chart.yaml
+++ b/k8s/release/mi/mi-extraction-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-extraction-service
 home: https://github.com/hmcts/mi-extraction-service
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.0.0"
 type: application
 description: MI extraction service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.2
+    version: ~0.6.3
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-house-keeping-service/Chart.yaml
+++ b/k8s/release/mi/mi-house-keeping-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-house-keeping-service
 home: https://github.com/hmcts/mi-house-keeping-service
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.0.0"
 type: application
 description: MI House Keeping Service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.2
+    version: ~0.6.3
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-integration-service/Chart.yaml
+++ b/k8s/release/mi/mi-integration-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-integration-service
 home: https://github.com/hmcts/mi-integration-service
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.0.0"
 type: application
 description: MI integration service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.2
+    version: ~0.6.3
     repository: 'file://../common/job'

--- a/k8s/release/mi/mi-staging-service/Chart.yaml
+++ b/k8s/release/mi/mi-staging-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-staging-service
 home: https://github.com/hmcts/mi-staging-service
-version: 1.1.2
+version: 1.1.3
 appVersion: "1.0.0"
 type: application
 description: MI staging service
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.2
+    version: ~0.6.3
     repository: 'file://../common/job'


### PR DESCRIPTION
Using mi-extraction-service pod identity instead to match its immediate using service.

Removed globals.environment from the secret provider class naming to simplify its usage by other components.

Updated chart history to maintain visibility.