### PR TITLE
MI Update Azure Functions secrets

### DIFF
--- a/k8s/environments/dev/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/dev/common/mi/mi-azure-functions.yaml
@@ -23,6 +23,8 @@ spec:
       ADF_RESOURCEGROUP: mi-dev-rg
       ADF_NAME: mi-ingestion-adf-dev
       ADF_STORAGEACCOUNTNAME: miauditdev
+    keyVaultSecrets:
+      - encryption-publicKey
     environment: "dev"
     resourceGroup: "mi-dev-rg"
     subscriptionId: "867a878b-cb68-4de5-9741-361ac9e178b6"

--- a/k8s/environments/ithc/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/ithc/common/mi/mi-azure-functions.yaml
@@ -18,6 +18,13 @@ spec:
       app.kubernetes.io/instance: mi-azure-functions-deployment
       app.kubernetes.io/name: mi-azure-functions-deployment
     image: sdshmctspublic.azurecr.io/mi/azure-functions:pr-9-7ac7442
+    env:
+      APPINSIGHTS_INSTRUMENTATIONKEY: "dca44538-3493-497e-8375-05ef17511c98"
+      ADF_RESOURCEGROUP: mi-ithc-rg
+      ADF_NAME: mi-ingestion-adf-ithc
+      ADF_STORAGEACCOUNTNAME: miauditithc
+    keyVaultSecrets:
+      - encryption-publicKey
     environment: "ithc"
     resourceGroup: "mi-ithc-rg"
     subscriptionId: "ba71a911-e0d6-4776-a1a6-079af1df7139"

--- a/k8s/environments/sbox/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/sbox/common/mi/mi-azure-functions.yaml
@@ -23,6 +23,8 @@ spec:
       ADF_RESOURCEGROUP: mi-sbox-rg
       ADF_NAME: mi-ingestion-adf-sbox
       ADF_STORAGEACCOUNTNAME: miauditsbox
+    keyVaultSecrets:
+      - encryption-publicKey
     environment: "sbox"
     resourceGroup: "mi-sbox-rg"
     subscriptionId: "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"

--- a/k8s/environments/stg/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/stg/common/mi/mi-azure-functions.yaml
@@ -18,6 +18,13 @@ spec:
       app.kubernetes.io/instance: mi-azure-functions-deployment
       app.kubernetes.io/name: mi-azure-functions-deployment
     image: sdshmctspublic.azurecr.io/mi/azure-functions:stg-73c9410
+    env:
+      APPINSIGHTS_INSTRUMENTATIONKEY: "5be27762-da20-4aaf-bc55-6b95a0c6ef6d"
+      ADF_RESOURCEGROUP: mi-stg-rg
+      ADF_NAME: mi-ingestion-adf-stg
+      ADF_STORAGEACCOUNTNAME: miauditstg
+    keyVaultSecrets:
+      - encryption-publicKey
     environment: "stg"
     resourceGroup: "mi-stg-rg"
     subscriptionId: "74dacd4f-a248-45bb-a2f0-af700dc4cf68"

--- a/k8s/environments/test/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/test/common/mi/mi-azure-functions.yaml
@@ -23,6 +23,8 @@ spec:
       ADF_RESOURCEGROUP: mi-test-rg
       ADF_NAME: mi-ingestion-adf-test
       ADF_STORAGEACCOUNTNAME: miaudittest
+    keyVaultSecrets:
+      - encryption-publicKey
     environment: "test"
     resourceGroup: "mi-test-rg"
     subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"


### PR DESCRIPTION
Added mounting the encryption-publicKey secret for all envs (except prod)

### JIRA link (if applicable) ###



### Change description ###

Added mounting the encryption-publicKey secret for all envs (except prod)
This allows the mi-azure-functions to properly encrypt blobs on request.

Also added ingestion ADF config to ITHC and STG allowing the scheduled ingestion cleanup to run.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
