### PR TITLE
DTSPO-2879 - State store name update

### DIFF
--- a/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
@@ -55,7 +55,7 @@ spec:
                       - key: PIPELINE_METRICS_URL
                         value: https://sds-jenkins-pipeline-metrics-sbox.documents.azure.com/
                       - key: TF_STATE_STORAGE_TEMPLATE
-                        value: sdsstate
+                        value: mgmtstatestore
                       - key: TF_STATE_CONTAINER_TEMPLATE
                         value: "tfstate-"
                       - key: NONPROD_ENVIRONMENT_NAME


### PR DESCRIPTION
Updating tf_state_storage_template to match standard syntax. Previous setting matched pre-existing storage account name