### PR TITLE
Add local mi sftp server on stg for export tests.

### DIFF
--- a/k8s/environments/stg/common/mi/mi-sftp-server.yaml
+++ b/k8s/environments/stg/common/mi/mi-sftp-server.yaml
@@ -1,0 +1,68 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: mi-sftp-server
+  namespace: mi
+  labels:
+    app: mi-sftp-server
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app: mi-sftp-server
+      aadpodidbinding: mi-extraction-service
+  template:
+    metadata:
+      labels:
+        app: mi-sftp-server
+        aadpodidbinding: mi-extraction-service
+    spec:
+      initContainers:
+        - name: install
+          image: busybox
+          command: ["/bin/sh", "-c", "printf '%s:%s:1000::/files/mi-platform-export/'  $(cat /kvmnt/sftp-remote-user) $(cat /kvmnt/sftp-remote-password) > /sftp-config/users.conf"]
+          volumeMounts:
+            - name: azurekeyvault
+              mountPath: /kvmnt
+              readOnly: true
+            - name: config-cache
+              mountPath: /sftp-config
+      containers:
+        - name: mi-sftp-server
+          image: sdshmctspublic.azurecr.io/mi/sftp:1.0.0-release
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          volumeMounts:
+            - name: azurekeyvault
+              mountPath: /kvmnt
+              readOnly: true
+            - name: config-cache
+              mountPath: /etc/sftp
+          ports:
+            - containerPort: 22
+      volumes:
+        - name: azurekeyvault
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "mi-extraction-service-job-vault-secret-provider"
+        - name: config-cache
+          emptyDir: {}
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mi-sftp-server-svc
+  namespace: mi
+spec:
+  ports:
+    - protocol: TCP
+      port: 2000
+      targetPort: 22
+  selector:
+    app: mi-sftp-server


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Add local mi sftp server on stg for export tests.
This is so we don't push test data to MoJ SFTP.

Note this is a quick fix and we should migrate to use kustomize in the future.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
