### PR TITLE
hmis-902 add hmi-case-hq-emulator to hmi namespace

### DIFF
--- a/k8s/environments/sbox/common-overlay/hmi/azure-identity-patch.yaml
+++ b/k8s/environments/sbox/common-overlay/hmi/azure-identity-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/resourceID
+  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/hmi-sbox-mi
+- op: replace
+  path: /spec/clientID
+  value: ded186f5-4dfb-40c8-a938-7c10489ef9ae

--- a/k8s/environments/sbox/common-overlay/hmi/flux-patch.yaml
+++ b/k8s/environments/sbox/common-overlay/hmi/flux-patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: hmi-case-hq-emulator
+  namespace: hmi
+spec:
+  values:
+    java:
+      image: hmctspublic.azurecr.io/hmi/case-hq-emulator

--- a/k8s/environments/sbox/common-overlay/hmi/kustomization.yaml
+++ b/k8s/environments/sbox/common-overlay/hmi/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../namespaces/hmi
+
+patches:
+- target:
+    group: aadpodidentity.k8s.io
+    version: v1
+    kind: AzureIdentity
+    name: hmi
+  path: azure-identity-patch.yaml

--- a/k8s/namespaces/hmi/hmi-case-hq-emulator/hmi-case-hq-emulator.yaml
+++ b/k8s/namespaces/hmi/hmi-case-hq-emulator/hmi-case-hq-emulator.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: hmi-case-hq-emulator
+  namespace: hmi
+  annotations:
+    fluxcd.io/automated: "true"
+spec:
+  releaseName: hmi-case-hq-emulator
+  chart:
+    git: git@github.com:hmcts/hmi-case-hq-emulator
+    path: charts/hmi-case-hq-emulator
+    ref: master


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMIS-902


### Change description ###
Add the HMI namespace and new API


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X  ] No
```
