### PR TITLE
Revert "Upgrade CSI driver"

### DIFF
--- a/k8s/release/admin/secrets-csi-driver/secrets-csi-driver.yaml
+++ b/k8s/release/admin/secrets-csi-driver/secrets-csi-driver.yaml
@@ -4,12 +4,15 @@ kind: HelmRelease
 metadata:
   name: csi-secrets-store-provider-azure
   namespace: admin
+  annotations:
+    flux.weave.works/ignore: "false"
+    flux.weave.works/automated: "false"
 spec:
   releaseName: csi-secrets-store-provider-azure
   chart:
     repository: https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/
     name: csi-secrets-store-provider-azure
-    version: 0.2.0
+    version: 0.0.20
   values:
     secrets-store-csi-driver:
       syncSecret:


### PR DESCRIPTION
Reverts hmcts/shared-services-flux#1111

```
I0817 13:31:59.594168       1 request.go:668] Waited for 1.046232657s due to client-side throttling, not priority and fairness, request: GET:https://10.0.0.1:443/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=32s
F0817 13:32:00.748507       1 main.go:174] failed to run manager, error: failed to wait for secretproviderclasspodstatus caches to sync: no matches for kind "SecretProviderClassPodStatus" in version "secrets-store.csi.x-k8s.io/v1alpha1"
goroutine 31 [running]:
k8s.io/klog/v2.stacks(0xc0000c2001, 0xc00013a2c0, 0xed, 0x291)
	/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:1021 +0xb9
k8s.io/klog/v2.(*loggingT).output(0x2947320, 0xc000000003, 0x0, 0x0, 0xc000343ea0, 0x217a880, 0x7, 0xae, 0x0)
	/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:970 +0x191
k8s.io/klog/v2.(*loggingT).printf(0x2947320, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x1bab45d, 0x21, 0xc000189b90, 0x1, ...)
	/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:751 +0x191
k8s.io/klog/v2.Fatalf(...)
	/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:1509
main.main.func3(0x1de8200, 0xc00000a1e0, 0x1dcaeb0, 0xc00029bd80)
	/go/src/sigs.k8s.io/secrets-store-csi-driver/cmd/secrets-store-csi-driver/main.go:174 +0x195
created by main.main
	/go/src/sigs.k8s.io/secrets-store-csi-driver/cmd/secrets-store-csi-driver/main.go:171 +0xdf2

```