### PR TITLE
DTSPO-4675 - add empty nodeselector to pod identity config

### DIFF
--- a/k8s/namespaces/admin/aad-pod-identity/patches/sbox/aad-pod-id.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/patches/sbox/aad-pod-id.yaml
@@ -15,7 +15,7 @@ spec:
         key: CriticalAddonsOnly
         operator: Equal
         value: "true"
-      nodeSelector:
+      nodeSelector:  # This can be removed once the changes to use the system node pool are in prod
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/namespaces/admin/aad-pod-identity/patches/sbox/aad-pod-id.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/patches/sbox/aad-pod-id.yaml
@@ -15,6 +15,7 @@ spec:
         key: CriticalAddonsOnly
         operator: Equal
         value: "true"
+      nodeSelector:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,4 +44,4 @@ spec:
                 operator: In
                 values:
                 - system
-      nodeSelector: {}  # This can be removed once the changes to use the system node pool are in prod 
+      nodeSelector:  # This can be removed once the changes to use the system node pool are in prod


### PR DESCRIPTION
### Change description ###
- removing the brackets as they seem to be ignored and don't override the existing values. Tried a kustomize build and the nodeselector is gone after just leaving it blank.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
