### PR TITLE
Disable prometheus log analytics ingestion

### DIFF
--- a/k8s/common/omsagent-configmap.yaml
+++ b/k8s/common/omsagent-configmap.yaml
@@ -69,7 +69,7 @@ data:
         #     set this to `https` & most likely set the tls config.
         # - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
         # - prometheus.io/port: If port is not 9102 use this annotation
-        monitor_kubernetes_pods = true
+        monitor_kubernetes_pods = false
 
         ## Restricts Kubernetes monitoring to namespaces for pods that have annotations set and are scraped using the monitor_kubernetes_pods setting.
         ## This will take effect when monitor_kubernetes_pods is set to true


### PR DESCRIPTION
This scraping is incurring significant ingestion charges and consists largely of verbose DNS statistics
