### PR TITLE
PTL - update netbox redis secret

### DIFF
--- a/k8s/environments/ptl/common/secrets/netbox-redis.yaml
+++ b/k8s/environments/ptl/common/secrets/netbox-redis.yaml
@@ -1,24 +1,24 @@
-apiVersion: ENC[AES256_GCM,data:04k=,iv:aqbKZpqjjevXUpB4FNMsrHm4DoL2n4mHYjSxKrK4W98=,tag:SSKoLsGrpd3w3nV6PuDZag==,type:str]
+apiVersion: ENC[AES256_GCM,data:r68=,iv:cbHjg95H5pI3+AfeQYpw9sQ62tmaL2ZI17yG958Xubs=,tag:YG6o+MC9U6ORckJDHiDPrA==,type:str]
 data:
-  redis-password: ENC[AES256_GCM,data:ki7sORG3okO7JEyagtGuBShduUw59nbb4EfuX5GEilWVRID+3UjbfjxEqhr/PsJeIASBuaI0XXehlKJ5,iv:1/ee4QrgdbvyPT9oYNM1f1kWOIALG0zJZE5J/ouQadg=,tag:QQXQr/PwrT1UyTvM9WsbtQ==,type:str]
-kind: ENC[AES256_GCM,data:0nCL+Q1Z,iv:AbZwED5v+ap+yYsY2gzgQkSnodPMXuG0iVPadLeYHnc=,tag:uEJXNRSaLRcbfQwHaR3/Eg==,type:str]
+  redis-password: ENC[AES256_GCM,data:M+nZDzBZaBA7TcpcGkdK3gOQ6Tu6BkbB3Ectl8o2FVXXCbk2+6DSHzzZ/qmnyVYKmk4Vu0HNrx0Xrxi9,iv:DBzWtiSQxqivvWByJq/L+O31WC93Bzy16QDOOZzfspw=,tag:bntjH+vD+NcIZTvZpiTt2Q==,type:str]
+kind: ENC[AES256_GCM,data:EBqcdns0,iv:jZeTDUR7aMxzEARmGALVra/9PZ9j5wrzDTRnKfkGpGg=,tag:EofdRKxdPeb14JcHPWN4lA==,type:str]
 metadata:
   creationTimestamp: null
-  name: ENC[AES256_GCM,data:8ILOg2QCk9a55gPo,iv:D477AlUNSe5jrASQZAz6e4s1J9X6XAhhlCN76JTfuWw=,tag:IZK1HaTsw5uOwFlK1ukjOg==,type:str]
-  namespace: ENC[AES256_GCM,data:kl96ORBI,iv:ccb/GKUsyL5GrlTJ+rU8b7ItymZ29iYhsj1BtaowNi8=,tag:xEfqVm2e1CaLMoc1SXI8CA==,type:str]
+  name: ENC[AES256_GCM,data:25LiKa0hayvS8in1,iv:kt63KvnqiXDpyYpRsDfPtcJOKVRwLNLHnn6oJ2MSc5I=,tag:WgfXICQjihf8jdokXCOsCQ==,type:str]
+  namespace: ENC[AES256_GCM,data:rTXvNO/O,iv:+pRTkfvRH7EVe31jChPweqOLBx330s6JS8ze9m37zw4=,tag:P6QiuuCNoF60wGoF48cS4w==,type:str]
 sops:
   kms: []
   gcp_kms: []
   azure_kv:
-  - vault_url: https://dtssdsptl.vault.azure.net
+  - vault_url: https://dtssdsptlsbox.vault.azure.net
     name: sops-key
-    version: b047792919f74e6c875ba3a8945ed7a9
-    created_at: "2021-10-04T13:29:32Z"
-    enc: YyXxUpjfDuLr7zXJfGSdxCQ2ODuIoeNW42wAPaANgJre4X36IxYdeb_ZSXRrGT9TYk_caw5Y1POTntrz1vmra8JajxTTsHRjqGNvWvL8r810SUZJLNJDUcnag6iIuoJn1eXlTsas2uB6f0fv4mQOTcFWRFZ_rRw5eK4ihPFlf7YazdMHrn4820ileOD3OJZeWqfphZkwzSTL_p97AoRqvRFS7YpTHJINynBt8yGiwpNXq7rrQB4HSH3uGNmIKt644bEuhYBHPW9GrTxzR7g7o5PDBaBneuiNYK6omWlIktZqnvgJAv8PCtcsVaxjjJ3N6pNjdy5ZDCoZwcjutL7H2Q
+    version: a443393a134b4e33ae9f541d2f14747e
+    created_at: "2021-10-20T13:00:21Z"
+    enc: K3KSsEsWpi1fjc7C_w_ptVYNs09i9PqqAorpGGfbBd-Uptdb0pDFltmEm93s332VZUh9duFiVHCZib10TMJVBuAy-PtrT4kemXVRwOvBvwhwLzccQOHVlB_OwJYDPQxrt_a5kga3rzfHLptnrFjVyFNYcC0v9sRGBvOkSeaU2vy6WBUSxH3ZX8DVOeSsaM5KB8VYT0K_qaS7HLa9lztIN59adTfNGM2h_De8b3Cy2dp6G7o1kX194PMN-il9IJOrH01-HjDnICuYjWPvAZW95UxMXgITax-PKn1V9XM_-TOHC9ItP7Cs8qHzReup8llcUPqU6lqG9FUAMfycZ_6ApQ
   hc_vault: []
   age: []
-  lastmodified: "2021-10-04T13:29:33Z"
-  mac: ENC[AES256_GCM,data:DAMWRasSSTd8nw4NDEEh3S5sG0qje/6skx6xj9D7HMF+rDrVKBKudh9bX4ODKitXopnacb4xn+QEd8oxS6WEe17iulkWYmPtNA31AdNUpviY8uB9o90b7l2ptOmpAHxWCBLT73qdXMpgDtI8m8hvvZG1BOd/QLm0IzKbTNRE3JI=,iv:Mw55n2cLMVRei2aYiMuOS7MNbYCOPqjPNwkjKvA6v0U=,tag:iiKY4UnOwCvO1EquS9Q1pw==,type:str]
+  lastmodified: "2021-10-20T13:00:22Z"
+  mac: ENC[AES256_GCM,data:My8i9X9wxJRuE2F09WvNVFIqIpmtwXjGDpEcBDb8X7fw2KNvmEYpyWNEv5LzxCBuM/aQLMtEnfYLQisNCNqgIRlJhzg+INkbrS34oMnJ0F8UOMAIxFmAWePh23NgvB+F0R5qxJv6iG+0nIGZ9pe/lYcPEfi8S7YQnwaHzPyPncc=,iv:1b0qJcslUf10QQF4m0+X6EIKNMHfiS+5Scjc02naPrs=,tag:qyAAyEFuRNnkh/BLhxLLfA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.7.1


### PR DESCRIPTION
### Change description ###

current access key is incorrect - updating to use PTL instance's
(I reverted https://github.com/hmcts/shared-services-flux/pull/1287 as I updated the wrong environment, this PR is to update correctly)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
