### PR TITLE
Updating mi azure functions prod tag manually

### DIFF
--- a/k8s/environments/prod/common/mi/mi-azure-functions.yaml
+++ b/k8s/environments/prod/common/mi/mi-azure-functions.yaml
@@ -18,7 +18,7 @@ spec:
     labels:
       app.kubernetes.io/instance: mi-azure-functions-deployment
       app.kubernetes.io/name: mi-azure-functions-deployment
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:prod-14cbe6a
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:prod-f6069a7
     env:
       APPINSIGHTS_INSTRUMENTATIONKEY: "8bfa6e68-ae68-442c-a237-83cde3b092f3"
       ADF_RESOURCEGROUP: mi-prod-rg


### PR DESCRIPTION
### Change description ###

Flux doesn't seem to have auto released the latest prod tag for the MI Azure Functions. Raising this manual PR for now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
